### PR TITLE
Expose require/module internals to global regardless of nodeIntegration

### DIFF
--- a/lib/renderer/init.js
+++ b/lib/renderer/init.js
@@ -100,11 +100,13 @@ if (window.location.protocol === 'chrome-devtools:') {
   }
 }
 
-if (nodeIntegration === 'true') {
-  // Export node bindings to global.
-  global.require = require
-  global.module = module
+// Expose require no matter what; for some reason, our preload script's require doesn't work
+// in the same context as this one does.
+global.require = require
+// And module is tied to our require's resolution.
+global.module = module
 
+if (nodeIntegration === 'true') {
   // Set the __filename to the path of html file if it is file: protocol.
   if (window.location.protocol === 'file:') {
     var pathname = process.platform === 'win32' && window.location.pathname[0] === '/' ? window.location.pathname.substr(1) : window.location.pathname


### PR DESCRIPTION
This is relevant for our nodeIntegration removal work. Our preload script will
overwrite those two globals once it's done using them.

---

**Before merging**, however, we need to discuss this change internally.