### PR TITLE
[WIP] Use SW_SHOW when making top-level windows visible.

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -94,3 +94,4 @@ never_let_a_non-zero-size_pixel_snap_to_zero_size.patch
 fix_hi-dpi_transitions_on_catalina.patch
 typemap.patch
 ignore_mouse_buttons_other_than_left_right_middle.patch
+use_sw_show_for_initial_state_not_shownormal.patch

--- a/patches/chromium/use_sw_show_for_initial_state_not_shownormal.patch
+++ b/patches/chromium/use_sw_show_for_initial_state_not_shownormal.patch
@@ -1,0 +1,21 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Mack Straight <mack@discordapp.com>
+Date: Wed, 5 Feb 2020 17:59:26 -0800
+Subject: Use SW_SHOW for initial state, not SHOWNORMAL.
+
+This allows ui::SHOW_STATE_DEFAULT to be used to show a window without
+altering its tiling or maximize state.
+
+diff --git a/ui/views/widget/desktop_aura/desktop_window_tree_host_win.cc b/ui/views/widget/desktop_aura/desktop_window_tree_host_win.cc
+index cd47d499eead56f7228ab5e8b862c766274ea460..980c314d47fde5245dabc72f8ef6137c2867be8b 100644
+--- a/ui/views/widget/desktop_aura/desktop_window_tree_host_win.cc
++++ b/ui/views/widget/desktop_aura/desktop_window_tree_host_win.cc
+@@ -724,7 +724,7 @@ bool DesktopWindowTreeHostWin::IsModal() const {
+ }
+ 
+ int DesktopWindowTreeHostWin::GetInitialShowState() const {
+-  return CanActivate() ? SW_SHOWNORMAL : SW_SHOWNOACTIVATE;
++  return CanActivate() ? SW_SHOW : SW_SHOWNA;
+ }
+ 
+ bool DesktopWindowTreeHostWin::WillProcessWorkAreaChange() const {

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -1384,7 +1384,7 @@ ui::WindowShowState NativeWindowViews::GetRestoredState() {
   if (IsFullscreen())
     return ui::SHOW_STATE_FULLSCREEN;
 
-  return ui::SHOW_STATE_NORMAL;
+  return ui::SHOW_STATE_DEFAULT;
 }
 
 void NativeWindowViews::MoveBehindTaskBarIfNeeded() {


### PR DESCRIPTION
This prevents a problem where a docked window loses its dock state when
hidden and then shown again.

All the funfacts are not done, I just wanted to mess around with the Electron patching process a bit to see how it works and oh boy is my workflow for this messed up.

Q: how are you doing it? particularly for Windows patches.
Q: is having ui/ in the patches config thing the right thing? `git-export-patches` etc seem to expect these directories to correspond to git repos, and trying to export via that route to `electron/patches/ui` did not go well (copied all the chromium patches). I moved this one patch from `ui/` back to `chromium/` to pacify the script.
Q: Is there some relatively ez way to run all the tests and stuff, any useful links or steps or w/e you've got would help