### PR TITLE
Don't crash if MessageSync fails

### DIFF
--- a/shell/renderer/api/atom_api_renderer_ipc.cc
+++ b/shell/renderer/api/atom_api_renderer_ipc.cc
@@ -102,7 +102,8 @@ class IPCRenderer : public mate::Wrappable<IPCRenderer> {
 
     electron_browser_ptr_->MessageSync(internal, channel, std::move(arguments),
                                        &result);
-    return std::move(result.GetList().at(0));
+    return result.GetList().size() > 0 ? std::move(result.GetList().at(0))
+                                       : base::Value();
   }
 
  private:


### PR DESCRIPTION
This doesn't feel overly correct but it's somewhat congruent to https://github.com/electron/electron/blob/master/shell/renderer/api/electron_api_renderer_ipc.cc#L169 in master, which also just returns an empty value for some kinds of failures. The problem here is that the mojo gunk backing `MessageSync` can fail in various ways and return `false` instead of populating `result` with a value, leading to an out of bounds `.at()` which throws.

The documentation of what's actually supposed to happen is woefully underspecified, so ya.

This patch is irrelevant in a post-e8 world since it now uses SCA instead there.