### PR TITLE
backport macOS VoiceOver fix from official repo

### DIFF
--- a/shell/browser/ui/cocoa/atom_ns_window.mm
+++ b/shell/browser/ui/cocoa/atom_ns_window.mm
@@ -120,7 +120,18 @@ bool ScopedDisableResize::disable_resize_ = false;
                           [NSButtonCell class], @"RenderWidgetHostViewCocoa"];
 
   NSArray* children = [super accessibilityAttributeValue:attribute];
-  return [children filteredArrayUsingPredicate:predicate];
+  NSMutableArray* mutableChildren = [[children mutableCopy] autorelease];
+  [mutableChildren filterUsingPredicate:predicate];
+
+  // We need to add the web contents: Without us doing so, VoiceOver
+  // users will be able to navigate up the a11y tree, but not back down.
+  // The content view contains the "web contents", which VoiceOver
+  // immediately understands.
+  NSView* contentView =
+      [shell_->GetNativeWindow().GetNativeNSWindow() contentView];
+  [mutableChildren addObject:contentView];
+
+  return mutableChildren;
 }
 
 - (NSString*)accessibilityTitle {


### PR DESCRIPTION
Something changed in Electron 6 that prevented it from exposing an accessibility tree, meaning screenreader users on macOS [couldn't interact with the app at all](https://github.com/electron/electron/issues/17207). When Discord upgraded from Electron 4 to Electron 7, we inherited this issue.

However, it was fixed on Electron master in early March, and [backported to Electron 8 and 9](https://github.com/electron/electron/pull/22470), but 7 was not included. This PR backports that fix another step so that we can use it in our Electron 7 builds.