### PR TITLE
Allow -r in `NODE_OPTIONS`

### DIFF
--- a/shell/common/node_bindings.cc
+++ b/shell/common/node_bindings.cc
@@ -192,7 +192,8 @@ void SetNodeOptions(base::Environment* env) {
 
   // Subset of options allowed in packaged apps
   const std::set<std::string> allowed_in_packaged = {"--max-http-header-size",
-                                                     "--http-parser"};
+                                                     "--http-parser",
+                                                     "-r"};
 
   if (env->HasVar("NODE_OPTIONS")) {
     std::string options;


### PR DESCRIPTION
I don't have a good handle on how discord ships the native client, but on or around the 9.x upgrade, `IsPackagedApp` started being true which means the client no longer accepts any useful `NODE_OPTIONS` options.