### PR TITLE
Add a new builtin module that allows the creation of a custom MediaStream

### DIFF
--- a/default_app/preload.ts
+++ b/default_app/preload.ts
@@ -1,4 +1,4 @@
-import { ipcRenderer, contextBridge } from 'electron';
+import { ipcRenderer, contextBridge, discord } from 'electron';
 
 async function getOcticonSvg (name: string) {
   try {
@@ -48,6 +48,8 @@ async function initialize () {
   }
 }
 
+discord.install('discordStream');
 contextBridge.exposeInMainWorld('electronDefaultApp', {
-  initialize
+  initialize,
+  p: process
 });

--- a/default_app/preload.ts
+++ b/default_app/preload.ts
@@ -1,4 +1,4 @@
-import { ipcRenderer, contextBridge, discord } from 'electron';
+import { ipcRenderer, contextBridge } from 'electron';
 
 async function getOcticonSvg (name: string) {
   try {
@@ -48,8 +48,6 @@ async function initialize () {
   }
 }
 
-discord.install('discordStream');
 contextBridge.exposeInMainWorld('electronDefaultApp', {
-  initialize,
-  p: process
+  initialize
 });

--- a/discord/discord_video_source.cc
+++ b/discord/discord_video_source.cc
@@ -1,0 +1,255 @@
+#include "electron/discord/discord_video_source.h"
+
+#include "gpu/command_buffer/client/shared_image_interface.h"
+#include "gpu/command_buffer/common/shared_image_usage.h"
+#include "gpu/ipc/common/gpu_memory_buffer_support.h"
+#include "media/video/gpu_video_accelerator_factories.h"
+
+#include "third_party/blink/public/platform/platform.h"
+#include "third_party/blink/renderer/platform/scheduler/public/post_cross_thread_task.h"
+#include "third_party/blink/renderer/platform/wtf/cross_thread_functional.h"
+
+namespace WTF {
+
+// Template specializations of [1], needed to be able to pass WTF callbacks
+// that have VideoTrackAdapterSettings or gfx::Size parameters across threads.
+//
+// [1] third_party/blink/renderer/platform/wtf/cross_thread_copier.h.
+template <>
+struct CrossThreadCopier<void*> : public CrossThreadCopierPassThrough<void*> {
+  STATIC_ONLY(CrossThreadCopier);
+};
+
+}  // namespace WTF
+
+namespace blink {
+
+std::mutex MediaStreamDiscordVideoSource::stream_mutex_;
+
+class MediaStreamDiscordVideoSource::VideoSourceDelegate
+    : public WTF::ThreadSafeRefCounted<VideoSourceDelegate> {
+ public:
+  VideoSourceDelegate(
+      scoped_refptr<base::SingleThreadTaskRunner> io_task_runner,
+      VideoCaptureDeliverFrameCB new_frame_callback);
+
+  void OnFrame(const std::string& streamId,
+               const DiscordFrame& frame,
+               DiscordFrameReleaseCB releaseCB,
+               void* userData);
+
+ protected:
+  friend class WTF::ThreadSafeRefCounted<VideoSourceDelegate>;
+
+  ~VideoSourceDelegate() {}
+
+  void DoRenderFrameOnIOThread(scoped_refptr<media::VideoFrame> video_frame,
+                               base::TimeTicks estimated_capture_time);
+#ifdef OS_WINDOWS
+  void DoNativeFrameOnMediaThread(HANDLE texture,
+                                  gfx::Size size,
+                                  int64_t timestamp_us,
+                                  void* releaseCBVoid,
+                                  void* userData);
+#endif
+
+  scoped_refptr<base::SingleThreadTaskRunner> io_task_runner_;
+  scoped_refptr<base::SequencedTaskRunner> media_task_runner_;
+
+  // |frame_callback_| is accessed on the IO thread.
+  VideoCaptureDeliverFrameCB frame_callback_;
+
+  media::GpuVideoAcceleratorFactories* gpu_factories_;
+  std::unique_ptr<gpu::GpuMemoryBufferSupport> gpu_memory_buffer_support_;
+};
+
+MediaStreamDiscordVideoSource::VideoSourceDelegate::VideoSourceDelegate(
+    scoped_refptr<base::SingleThreadTaskRunner> io_task_runner,
+    VideoCaptureDeliverFrameCB new_frame_callback)
+    : io_task_runner_(io_task_runner),
+      frame_callback_(std::move(new_frame_callback)),
+      gpu_factories_(Platform::Current()->GetGpuFactories()),
+      gpu_memory_buffer_support_(new gpu::GpuMemoryBufferSupport()) {
+  if (gpu_factories_) {
+    media_task_runner_ = gpu_factories_->GetTaskRunner();
+  }
+}
+
+void MediaStreamDiscordVideoSource::VideoSourceDelegate::
+    DoRenderFrameOnIOThread(scoped_refptr<media::VideoFrame> video_frame,
+                            base::TimeTicks estimated_capture_time) {
+  DCHECK(io_task_runner_->BelongsToCurrentThread());
+  TRACE_EVENT0("webrtc", "VideoSourceDelegate::DoRenderFrameOnIOThread");
+  frame_callback_.Run(std::move(video_frame), estimated_capture_time);
+}
+
+#ifdef OS_WINDOWS
+void MediaStreamDiscordVideoSource::VideoSourceDelegate::
+    DoNativeFrameOnMediaThread(HANDLE texture,
+                               gfx::Size size,
+                               int64_t timestamp_us,
+                               void* releaseCBVoid,
+                               void* userData) {
+  DiscordFrameReleaseCB releaseCB =
+      reinterpret_cast<DiscordFrameReleaseCB>(releaseCBVoid);
+  gfx::GpuMemoryBufferHandle buffer_handle{};
+  buffer_handle.type = gfx::DXGI_SHARED_HANDLE;
+  buffer_handle.dxgi_handle = base::win::ScopedHandle(texture);
+
+  if (!gpu_factories_) {
+    releaseCB(userData);
+    return;
+  }
+  auto* sii = gpu_factories_->SharedImageInterface();
+  if (!sii) {
+    releaseCB(userData);
+    return;
+  }
+  auto buffer_impl =
+      gpu_memory_buffer_support_->CreateGpuMemoryBufferImplFromHandle(
+          std::move(buffer_handle), size, gfx::BufferFormat::RGBA_8888,
+          gfx::BufferUsage::GPU_READ, base::DoNothing());
+  auto mailbox = sii->CreateSharedImage(
+      buffer_impl.get(), gpu_factories_->GpuMemoryBufferManager(),
+      gfx::ColorSpace::CreateSRGB(), kTopLeft_GrSurfaceOrigin,
+      kOpaque_SkAlphaType,
+      gpu::SHARED_IMAGE_USAGE_GLES2 | gpu::SHARED_IMAGE_USAGE_RASTER |
+          gpu::SHARED_IMAGE_USAGE_DISPLAY | gpu::SHARED_IMAGE_USAGE_SCANOUT);
+  gpu::MailboxHolder mailbox_holder_array[media::VideoFrame::kMaxPlanes];
+  mailbox_holder_array[0] = gpu::MailboxHolder(
+      mailbox, sii->GenUnverifiedSyncToken(),
+      gpu_factories_->ImageTextureTarget(buffer_impl->GetFormat()));
+
+  scoped_refptr<media::VideoFrame> video_frame =
+      media::VideoFrame::WrapExternalGpuMemoryBuffer(
+          gfx::Rect(size), size, std::move(buffer_impl), mailbox_holder_array,
+          base::DoNothing(), base::TimeDelta::FromMicroseconds(timestamp_us));
+  PostCrossThreadTask(
+      *io_task_runner_.get(), FROM_HERE,
+      CrossThreadBindOnce(&VideoSourceDelegate::DoRenderFrameOnIOThread,
+                          WrapRefCounted(this), video_frame,
+                          base::TimeTicks()));
+  video_frame->AddDestructionObserver(ConvertToBaseOnceCallback(
+      CrossThreadBindOnce(releaseCB, CrossThreadUnretained(userData))));
+}
+#endif
+
+MediaStreamDiscordVideoSource::MediaStreamDiscordVideoSource(
+    const std::string& streamId)
+    : stream_id_(streamId) {}
+
+MediaStreamDiscordVideoSource::~MediaStreamDiscordVideoSource() {
+  StopSourceImpl();
+}
+
+void MediaStreamDiscordVideoSource::StartSourceImpl(
+    VideoCaptureDeliverFrameCB frame_callback,
+    EncodedVideoFrameCB encoded_frame_callback) {
+  delegate_ = base::MakeRefCounted<VideoSourceDelegate>(
+      io_task_runner(), std::move(frame_callback));
+  {
+    std::lock_guard<std::mutex> lock(stream_mutex_);
+    if (!by_stream_id_) {
+      by_stream_id_ =
+          new std::unordered_map<std::string,
+                                 scoped_refptr<VideoSourceDelegate>>();
+    }
+    by_stream_id_->erase(stream_id_);
+    by_stream_id_->emplace(stream_id_, delegate_);
+  }
+
+  OnStartDone(mojom::MediaStreamRequestResult::OK);
+}
+
+void MediaStreamDiscordVideoSource::StopSourceImpl() {
+  if (delegate_.get()) {
+    std::lock_guard<std::mutex> lock(stream_mutex_);
+    auto it = by_stream_id_->find(stream_id_);
+    if (it != by_stream_id_->end() && it->second == delegate_) {
+      by_stream_id_->erase(it);
+    }
+    delegate_.reset();
+  }
+}
+
+void MediaStreamDiscordVideoSource::VideoSourceDelegate::OnFrame(
+    const std::string& streamId,
+    const DiscordFrame& frame,
+    DiscordFrameReleaseCB releaseCB,
+    void* userData) {
+  gfx::Size size(frame.width, frame.height);
+  scoped_refptr<media::VideoFrame> video_frame;
+  auto type = static_cast<webrtc::VideoFrameBuffer::Type>(frame.type);
+
+  if (type == webrtc::VideoFrameBuffer::Type::kI420) {
+    video_frame = media::VideoFrame::WrapExternalYuvData(
+        media::PIXEL_FORMAT_I420, size, gfx::Rect(size), size, frame.y_stride,
+        frame.u_stride, frame.v_stride, frame.y, frame.u, frame.v,
+        base::TimeDelta::FromMicroseconds(frame.timestamp_us));
+#ifdef OS_WINDOWS
+  } else if (type == webrtc::VideoFrameBuffer::Type::kNative) {
+    if (!gpu_factories_) {
+      releaseCB(userData);
+      return;
+    }
+    // shared textures need to be processed on the media task runner,
+    // not the IO task runner
+    PostCrossThreadTask(
+        *media_task_runner_.get(), FROM_HERE,
+        CrossThreadBindOnce(
+            &VideoSourceDelegate::DoNativeFrameOnMediaThread,
+            WrapRefCounted(this),
+            CrossThreadUnretained(reinterpret_cast<HANDLE>(frame.y)), size,
+            frame.timestamp_us,
+            CrossThreadUnretained(reinterpret_cast<void*>(releaseCB)),
+            CrossThreadUnretained(userData)));
+    return;
+#endif
+  } else {
+    // currently unsupported type
+    releaseCB(userData);
+    return;
+  }
+
+  PostCrossThreadTask(
+      *io_task_runner_.get(), FROM_HERE,
+      CrossThreadBindOnce(&VideoSourceDelegate::DoRenderFrameOnIOThread,
+                          WrapRefCounted(this), video_frame,
+                          base::TimeTicks()));
+  video_frame->AddDestructionObserver(ConvertToBaseOnceCallback(
+      CrossThreadBindOnce(releaseCB, CrossThreadUnretained(userData))));
+}
+
+// static
+void MediaStreamDiscordVideoSource::OnFrame(const std::string& streamId,
+                                            const DiscordFrame& frame,
+                                            DiscordFrameReleaseCB releaseCB,
+                                            void* userData) {
+  std::lock_guard<std::mutex> lock(stream_mutex_);
+  if (!by_stream_id_) {
+    return;
+  }
+  auto it = by_stream_id_->find(streamId);
+  if (it != by_stream_id_->end()) {
+    scoped_refptr<VideoSourceDelegate> delegate = it->second;
+    delegate->OnFrame(streamId, frame, releaseCB, userData);
+  }
+}
+
+std::unordered_map<
+    std::string,
+    scoped_refptr<MediaStreamDiscordVideoSource::VideoSourceDelegate>>*
+    MediaStreamDiscordVideoSource::by_stream_id_;
+
+}  // namespace blink
+
+extern "C" {
+__declspec(dllexport) void DeliverDiscordFrame(
+    const char* streamId,
+    const blink::DiscordFrame& frame,
+    blink::DiscordFrameReleaseCB releaseCB,
+    void* userData) {
+  blink::MediaStreamDiscordVideoSource::OnFrame(streamId, frame, releaseCB,
+                                                userData);
+}
+}

--- a/discord/discord_video_source.h
+++ b/discord/discord_video_source.h
@@ -1,0 +1,59 @@
+#ifndef THIRD_PARTY_BLINK_RENDERER_MODULES_DISCORD_DISCORD_VIDEO_SOURCE_H_
+#define THIRD_PARTY_BLINK_RENDERER_MODULES_DISCORD_DISCORD_VIDEO_SOURCE_H_
+
+#include <memory>
+#include <mutex>
+
+#include "base/macros.h"
+#include "third_party/blink/public/platform/modules/mediastream/web_media_stream_source.h"
+#include "third_party/blink/public/web/modules/mediastream/media_stream_video_source.h"
+#include "third_party/blink/renderer/modules/modules_export.h"
+#include "third_party/webrtc/api/media_stream_interface.h"
+
+namespace blink {
+
+struct DiscordFrame {
+  int64_t timestamp_us;
+  uint8_t* y;
+  uint8_t* u;
+  uint8_t* v;
+  int32_t y_stride;
+  int32_t u_stride;
+  int32_t v_stride;
+  int32_t width;
+  int32_t height;
+  int32_t type;
+};
+using DiscordFrameReleaseCB = void (*)(void*);
+
+class MODULES_EXPORT MediaStreamDiscordVideoSource
+    : public MediaStreamVideoSource {
+ public:
+  MediaStreamDiscordVideoSource(const std::string& streamId);
+  ~MediaStreamDiscordVideoSource() override;
+
+  static void OnFrame(const std::string& streamId,
+                      const DiscordFrame& frame,
+                      DiscordFrameReleaseCB releaseCB,
+                      void* userData);
+
+ protected:
+  // Implements MediaStreamVideoSource.
+  void StartSourceImpl(VideoCaptureDeliverFrameCB frame_callback,
+                       EncodedVideoFrameCB encoded_frame_callback) override;
+  void StopSourceImpl() override;
+
+ private:
+  DISALLOW_COPY_AND_ASSIGN(MediaStreamDiscordVideoSource);
+
+  class VideoSourceDelegate;
+  scoped_refptr<VideoSourceDelegate> delegate_;
+  std::string stream_id_;
+
+  static std::unordered_map<std::string, scoped_refptr<VideoSourceDelegate>>*
+      by_stream_id_;
+  static std::mutex stream_mutex_;
+};
+}  // namespace blink
+
+#endif  // THIRD_PARTY_BLINK_RENDERER_MODULES_DISCORD_DISCORD_VIDEO_SOURCE_H_

--- a/discord/discord_video_source.h
+++ b/discord/discord_video_source.h
@@ -1,5 +1,5 @@
-#ifndef THIRD_PARTY_BLINK_RENDERER_MODULES_DISCORD_DISCORD_VIDEO_SOURCE_H_
-#define THIRD_PARTY_BLINK_RENDERER_MODULES_DISCORD_DISCORD_VIDEO_SOURCE_H_
+#ifndef DISCORD_DISCORD_VIDEO_SOURCE_H_
+#define DISCORD_DISCORD_VIDEO_SOURCE_H_
 
 #include <memory>
 #include <mutex>
@@ -12,14 +12,23 @@
 
 namespace blink {
 
-struct DiscordFrame {
-  int64_t timestamp_us;
+struct DiscordYUVFrame {
   uint8_t* y;
   uint8_t* u;
   uint8_t* v;
   int32_t y_stride;
   int32_t u_stride;
   int32_t v_stride;
+};
+
+struct DiscordFrame {
+  int64_t timestamp_us;
+  union {
+    DiscordYUVFrame yuv;
+#if defined(OS_WINDOWS)
+    HANDLE texture_handle;
+#endif
+  } frame;
   int32_t width;
   int32_t height;
   int32_t type;
@@ -56,4 +65,4 @@ class MODULES_EXPORT MediaStreamDiscordVideoSource
 };
 }  // namespace blink
 
-#endif  // THIRD_PARTY_BLINK_RENDERER_MODULES_DISCORD_DISCORD_VIDEO_SOURCE_H_
+#endif  // DISCORD_DISCORD_VIDEO_SOURCE_H_

--- a/discord/module.cc
+++ b/discord/module.cc
@@ -1,0 +1,86 @@
+#define INSIDE_BLINK 1
+
+#include "discord/discord_video_source.h"
+
+#include "content/public/renderer/render_frame.h"
+#include "shell/common/gin_helper/dictionary.h"
+#include "shell/common/node_includes.h"
+
+#include "third_party/blink/public/web/web_local_frame.h"
+#include "third_party/blink/renderer/core/execution_context/execution_context.h"
+#include "third_party/blink/renderer/modules/discord/discord_video_source.h"
+#include "third_party/blink/renderer/modules/mediastream/media_stream.h"
+#include "third_party/blink/renderer/modules/mediastream/media_stream_constraints_util.h"
+#include "third_party/blink/renderer/modules/mediastream/media_stream_video_track.h"
+#include "third_party/blink/renderer/platform/bindings/to_v8.h"
+#include "third_party/blink/renderer/platform/mediastream/media_stream_source.h"
+#include "third_party/blink/renderer/platform/wtf/uuid.h"
+
+namespace blink {
+
+void DiscordStream(const v8::FunctionCallbackInfo<v8::Value>& info) {
+  ExecutionContext* context =
+      ExecutionContext::From(info.GetIsolate()->GetCurrentContext());
+
+  auto* descriptor = MakeGarbageCollected<MediaStreamDescriptor>(
+      WTF::CreateCanonicalUUIDString(), MediaStreamComponentVector(),
+      MediaStreamComponentVector());
+
+  std::string streamId;
+  gin::ConvertFromV8(info.GetIsolate(), info[0], &streamId);
+
+  MediaStream* stream = MediaStream::Create(context, descriptor);
+  auto platform_source =
+      std::make_unique<MediaStreamDiscordVideoSource>(streamId);
+  auto* raw_platform_source = platform_source.get();
+  const WebString track_id(WTF::CreateCanonicalUUIDString());
+
+  auto* media_stream_source = MakeGarbageCollected<MediaStreamSource>(
+      track_id, MediaStreamSource::kTypeVideo, track_id, false);
+  media_stream_source->SetPlatformSource(std::move(platform_source));
+  MediaStreamSource::Capabilities capabilities;
+  capabilities.device_id = track_id;
+  media_stream_source->SetCapabilities(capabilities);
+  descriptor->AddRemoteTrack(MediaStreamVideoTrack::CreateVideoTrack(
+      raw_platform_source, MediaStreamVideoSource::ConstraintsOnceCallback(),
+      true));
+  V8SetReturnValue(info, ToV8(stream, info.Holder(), info.GetIsolate()));
+}
+}  // namespace blink
+
+namespace {
+
+void Install(gin::Arguments* args, const std::string& name) {
+  // Find our way to the main context from our isolate object
+  v8::Local<v8::Context> context = args->isolate()->GetCurrentContext();
+  blink::WebLocalFrame* frame = blink::WebLocalFrame::FrameForContext(context);
+  content::RenderFrame* renderFrame = content::RenderFrame::FromWebFrame(frame);
+  v8::Local<v8::Context> mainContext =
+      renderFrame->GetWebFrame()->MainWorldScriptContext();
+  // Get the global object (window) from the main context with a dictionary
+  // wrapper
+  gin_helper::Dictionary global(mainContext->GetIsolate(),
+                                mainContext->Global());
+
+  v8::Local<v8::Value> wrappedFunction;
+  // wrap our native function in a v8 object belonging to the main context
+  if (!v8::Function::New(mainContext, blink::DiscordStream,
+                         v8::Local<v8::Value>(), 1)
+           .ToLocal(&wrappedFunction)) {
+    args->isolate()->ThrowException(v8::Exception::Error(gin::StringToV8(
+        args->isolate(), "Failed to allocate function object")));
+    return;
+  }
+  global.SetReadOnlyNonConfigurable(name, wrappedFunction);
+}
+
+void Initialize(v8::Local<v8::Object> exports,
+                v8::Local<v8::Value> unused,
+                v8::Local<v8::Context> context,
+                void* priv) {
+  gin_helper::Dictionary dict(context->GetIsolate(), exports);
+  dict.SetMethod("install", Install);
+}
+}  // namespace
+
+NODE_LINKED_MODULE_CONTEXT_AWARE(electron_renderer_discord, Initialize)

--- a/discord/module.cc
+++ b/discord/module.cc
@@ -8,7 +8,6 @@
 
 #include "third_party/blink/public/web/web_local_frame.h"
 #include "third_party/blink/renderer/core/execution_context/execution_context.h"
-#include "third_party/blink/renderer/modules/discord/discord_video_source.h"
 #include "third_party/blink/renderer/modules/mediastream/media_stream.h"
 #include "third_party/blink/renderer/modules/mediastream/media_stream_constraints_util.h"
 #include "third_party/blink/renderer/modules/mediastream/media_stream_video_track.h"

--- a/filenames.gni
+++ b/filenames.gni
@@ -236,9 +236,11 @@ filenames = {
   ]
 
   lib_sources = [
-    "discord/overlay.h",
-
     "chromium_src/chrome/browser/process_singleton.h",
+    "discord/discord_video_source.cc",
+    "discord/discord_video_source.h",
+    "discord/module.cc",
+    "discord/overlay.h",
     "shell/app/command_line_args.cc",
     "shell/app/command_line_args.h",
     "shell/app/electron_content_client.cc",

--- a/lib/renderer/api/module-list.ts
+++ b/lib/renderer/api/module-list.ts
@@ -6,6 +6,7 @@ const enableRemoteModule = v8Util.getHiddenValue<boolean>(global, 'enableRemoteM
 export const rendererModuleList: ElectronInternal.ModuleEntry[] = [
   { name: 'contextBridge', loader: () => require('./context-bridge') },
   { name: 'crashReporter', loader: () => require('./crash-reporter') },
+  { name: 'discord', loader: () => process._linkedBinding('electron_renderer_discord') },
   { name: 'ipcRenderer', loader: () => require('./ipc-renderer') },
   { name: 'nativeImage', loader: () => require('./native-image') },
   { name: 'webFrame', loader: () => require('./web-frame') }

--- a/lib/sandboxed_renderer/api/module-list.ts
+++ b/lib/sandboxed_renderer/api/module-list.ts
@@ -8,6 +8,10 @@ export const moduleList: ElectronInternal.ModuleEntry[] = [
     loader: () => require('@electron/internal/renderer/api/crash-reporter')
   },
   {
+    name: 'discord',
+    loader: () => process._linkedBinding('electron_renderer_discord')
+  },
+  {
     name: 'ipcRenderer',
     loader: () => require('@electron/internal/renderer/api/ipc-renderer')
   },

--- a/shell/common/node_bindings.cc
+++ b/shell/common/node_bindings.cc
@@ -79,6 +79,7 @@
   V(electron_common_v8_util)             \
   V(electron_renderer_context_bridge)    \
   V(electron_renderer_crash_reporter)    \
+  V(electron_renderer_discord)           \
   V(electron_renderer_ipc)               \
   V(electron_renderer_web_frame)
 


### PR DESCRIPTION
This is the electron/chromium half of the new video pipeline. The integration is a little funny due to the way electron handles customizing chromium. Essentially there are patches to the chromium tree which are very flexible, but difficult to maintain and there are builtin node modules. The latter is easier to maintain, but our need to output real MediaStream objects means we can't use the normal context bridge which means we need to handle installing the function into the main context ourselves.

A couple other notes on this:
* Currently only supports i420 and shared textures (kNative, windows only), but I think that's all we need for our purposes currently
* Shared texture support needs some work before it works properly, but since those are only useful for screen capture preview, it doesn't block getting an initial version out
* Exposed interface is purely C, in part because we used to use different compilers for electron and discord_voice. Might not be necessary now that everything is clang