### PR TITLE
skid-proof video decode

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -157,3 +157,4 @@ ignore_mouse_buttons_other_than_left_right_middle.patch
 use_sw_show_for_initial_state_not_shownormal.patch
 disable_get_user_media.patch
 discord_implement_video_composition_mode_property.patch
+skid-proof_video_decoding_memory_use.patch

--- a/patches/chromium/skid-proof_video_decoding_memory_use.patch
+++ b/patches/chromium/skid-proof_video_decoding_memory_use.patch
@@ -1,0 +1,373 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Mack Straight <mack@discordapp.com>
+Date: Tue, 4 May 2021 03:23:02 -0700
+Subject: skid-proof video decoding memory use
+
+videos with inline resolution changes can use arbitrary amounts of
+memory to decode. upstream tried to fix this by checking for the OOM
+condition when allocating, but I found it to be inadequate -- the OOM
+crash just ends up happening elsewhere because we're still under severe
+memory pressure.
+
+instead, add a global memory budget for system memory allocated video
+frames. I set it to 768MB because that feels like it should be enough,
+but we can choose any value.
+
+re-evaluate current state of chromium once we upgrade and drop this fix
+if they put something better in.
+
+diff --git a/media/base/BUILD.gn b/media/base/BUILD.gn
+index 80cc2864762202bcf4211e8682d0fec3057bc655..2182186c0dca1be58caf4bba237d7ae8cddbd622 100644
+--- a/media/base/BUILD.gn
++++ b/media/base/BUILD.gn
+@@ -313,6 +313,8 @@ jumbo_source_set("base") {
+     "video_frame.h",
+     "video_frame_layout.cc",
+     "video_frame_layout.h",
++    "video_frame_memory_budget.cc",
++    "video_frame_memory_budget.h",
+     "video_frame_metadata.cc",
+     "video_frame_metadata.h",
+     "video_frame_pool.cc",
+@@ -577,6 +579,7 @@ source_set("unit_tests") {
+     "video_color_space_unittest.cc",
+     "video_decoder_config_unittest.cc",
+     "video_frame_layout_unittest.cc",
++    "video_frame_memory_budget_unittest.cc",
+     "video_frame_pool_unittest.cc",
+     "video_frame_unittest.cc",
+     "video_thumbnail_decoder_unittest.cc",
+diff --git a/media/base/limits.h b/media/base/limits.h
+index 72980b35e65077162b9f4290592c36a00ce2f3b2..412d85d6536256bfc7f8d972426297d8c2517bb0 100644
+--- a/media/base/limits.h
++++ b/media/base/limits.h
+@@ -81,6 +81,11 @@ enum {
+       16,  // Matches ffmpeg's MAX_AUTO_THREADS. Higher values can result in
+            // immediate out of memory errors for high resolution content. See
+            // https://crbug.com/893984
++
++  // Maximum number of bytes to be used to allocate system memory buffers for
++  // video frames.
++  kVideoFrameBufferMemoryBudget = 1024 * 1024 * 768,
++  kVideoFrameBufferMaxAllocationSize = 4096 * 4096 * 3,
+ };
+ 
+ }  // namespace limits
+diff --git a/media/base/video_frame.cc b/media/base/video_frame.cc
+index 0bb025a1d5ff8364ad0071e24166c950dc713895..e84f21da1dbfe99853c7fa0f075a548742ee1669 100644
+--- a/media/base/video_frame.cc
++++ b/media/base/video_frame.cc
+@@ -23,6 +23,7 @@
+ #include "media/base/format_utils.h"
+ #include "media/base/limits.h"
+ #include "media/base/timestamp_constants.h"
++#include "media/base/video_frame_memory_budget.h"
+ #include "media/base/video_util.h"
+ #include "ui/gfx/buffer_format_util.h"
+ #include "ui/gfx/geometry/point.h"
+@@ -1170,6 +1171,10 @@ VideoFrame::~VideoFrame() {
+ 
+   for (auto& callback : done_callbacks_)
+     std::move(callback).Run();
++
++  if (budget_allocation_.has_value()) {
++    VideoFrameMemoryBudget::Current()->Release(*budget_allocation_);
++  }
+ }
+ 
+ // static
+@@ -1237,8 +1242,7 @@ scoped_refptr<VideoFrame> VideoFrame::CreateFrameWithLayout(
+ 
+   scoped_refptr<VideoFrame> frame(new VideoFrame(
+       std::move(layout), storage, visible_rect, natural_size, timestamp));
+-  frame->AllocateMemory(zero_initialize_memory);
+-  return frame;
++  return frame->AllocateMemory(zero_initialize_memory) ? frame : nullptr;
+ }
+ 
+ // static
+@@ -1253,7 +1257,7 @@ gfx::Size VideoFrame::CommonAlignment(VideoPixelFormat format) {
+   return gfx::Size(max_sample_width, max_sample_height);
+ }
+ 
+-void VideoFrame::AllocateMemory(bool zero_initialize_memory) {
++bool VideoFrame::AllocateMemory(bool zero_initialize_memory) {
+   DCHECK_EQ(storage_type_, STORAGE_OWNED_MEMORY);
+   static_assert(0 == kYPlane, "y plane data must be index 0");
+ 
+@@ -1261,6 +1265,13 @@ void VideoFrame::AllocateMemory(bool zero_initialize_memory) {
+   const size_t total_buffer_size =
+       std::accumulate(plane_size.begin(), plane_size.end(), 0u);
+ 
++  if (!VideoFrameMemoryBudget::Current()->Request(total_buffer_size)) {
++    LOG(ERROR) << "Video frame memory budget exhausted";
++    return false;
++  }
++
++  budget_allocation_ = total_buffer_size;
++
+   uint8_t* data = reinterpret_cast<uint8_t*>(
+       base::AlignedAlloc(total_buffer_size, layout_.buffer_addr_align()));
+   if (zero_initialize_memory) {
+@@ -1274,6 +1285,7 @@ void VideoFrame::AllocateMemory(bool zero_initialize_memory) {
+     data_[plane] = data + offset;
+     offset += plane_size[plane];
+   }
++  return true;
+ }
+ 
+ bool VideoFrame::IsValidSharedMemoryFrame() const {
+diff --git a/media/base/video_frame.h b/media/base/video_frame.h
+index 6b1a5b455a7e7a37ad51fee38fe859b0980a99fc..737884abb16329eda743f302987a0dc7636954ac 100644
+--- a/media/base/video_frame.h
++++ b/media/base/video_frame.h
+@@ -598,7 +598,7 @@ class MEDIA_EXPORT VideoFrame : public base::RefCountedThreadSafe<VideoFrame> {
+   // alignment for each individual plane.
+   static gfx::Size CommonAlignment(VideoPixelFormat format);
+ 
+-  void AllocateMemory(bool zero_initialize_memory);
++  WARN_UNUSED_RESULT bool AllocateMemory(bool zero_initialize_memory);
+ 
+   // Calculates plane size.
+   // It first considers buffer size layout_ object provides. If layout's
+@@ -690,6 +690,8 @@ class MEDIA_EXPORT VideoFrame : public base::RefCountedThreadSafe<VideoFrame> {
+   // Sampler conversion information which is used in vulkan context for android.
+   base::Optional<gpu::VulkanYCbCrInfo> ycbcr_info_;
+ 
++  base::Optional<size_t> budget_allocation_;
++
+   DISALLOW_IMPLICIT_CONSTRUCTORS(VideoFrame);
+ };
+ 
+diff --git a/media/base/video_frame_memory_budget.cc b/media/base/video_frame_memory_budget.cc
+new file mode 100644
+index 0000000000000000000000000000000000000000..eaaa2ab6bbed02aeff33c1390d4a4621d4fc2bc7
+--- /dev/null
++++ b/media/base/video_frame_memory_budget.cc
+@@ -0,0 +1,72 @@
++#include "media/base/video_frame_memory_budget.h"
++
++#include "base/no_destructor.h"
++#include "base/numerics/safe_math.h"
++#include "base/threading/thread_local.h"
++
++namespace media {
++
++namespace {
++base::ThreadLocalPointer<VideoFrameMemoryBudget>&
++GetThreadLocalCurrentPointer() {
++  static base::NoDestructor<base::ThreadLocalPointer<VideoFrameMemoryBudget>>
++      tls;
++  return *tls;
++}
++}  // namespace
++
++VideoFrameMemoryBudget::VideoFrameMemoryBudget() {}
++
++VideoFrameMemoryBudget* VideoFrameMemoryBudget::Current() {
++  static base::NoDestructor<VideoFrameMemoryBudget> instance;
++  VideoFrameMemoryBudget* thread_local_budget =
++      GetThreadLocalCurrentPointer().Get();
++
++  if (thread_local_budget) {
++    return thread_local_budget;
++  }
++
++  return instance.get();
++}
++
++void VideoFrameMemoryBudget::SetThreadCurrentForTesting(
++    VideoFrameMemoryBudget* current) {
++  GetThreadLocalCurrentPointer().Set(current);
++}
++
++void VideoFrameMemoryBudget::SetMemoryLimit(size_t limit) {
++  memory_limit_ = limit;
++}
++
++void VideoFrameMemoryBudget::SetMaxAllocationSize(size_t limit) {
++  max_allocation_size_ = limit;
++}
++
++bool VideoFrameMemoryBudget::Request(size_t bytes) {
++  if (bytes > max_allocation_size_) {
++    return false;
++  }
++  while (true) {
++    size_t new_allocated;
++    size_t allocated{allocated_.load()};
++
++    if (!base::CheckAdd(allocated, bytes).AssignIfValid(&new_allocated)) {
++      return false;
++    }
++
++    if (new_allocated > memory_limit_) {
++      return false;
++    }
++
++    if (allocated_.compare_exchange_strong(allocated, new_allocated)) {
++      return true;
++    }
++  }
++}
++
++void VideoFrameMemoryBudget::Release(size_t bytes) {
++  DCHECK_GE(allocated_.load(), bytes);
++  allocated_ -= bytes;
++}
++
++}  // namespace media
+\ No newline at end of file
+diff --git a/media/base/video_frame_memory_budget.h b/media/base/video_frame_memory_budget.h
+new file mode 100644
+index 0000000000000000000000000000000000000000..ffe2c8e409c1b668ef4222fb500b3b809dddec58
+--- /dev/null
++++ b/media/base/video_frame_memory_budget.h
+@@ -0,0 +1,35 @@
++#ifndef MEDIA_BASE_VIDEO_FRAME_MEMORY_BUDGET_H_
++#define MEDIA_BASE_VIDEO_FRAME_MEMORY_BUDGET_H_
++
++#include <stddef.h>
++
++#include <atomic>
++
++#include "media/base/limits.h"
++
++namespace media {
++
++class VideoFrameMemoryBudget {
++ public:
++  VideoFrameMemoryBudget();
++  VideoFrameMemoryBudget(VideoFrameMemoryBudget const&) = delete;
++  VideoFrameMemoryBudget& operator=(VideoFrameMemoryBudget const&) = delete;
++  VideoFrameMemoryBudget(VideoFrameMemoryBudget&&) = delete;
++  VideoFrameMemoryBudget& operator=(VideoFrameMemoryBudget&&) = delete;
++
++  static VideoFrameMemoryBudget* Current();
++  static void SetThreadCurrentForTesting(VideoFrameMemoryBudget* current);
++  void SetMemoryLimit(size_t limit);
++  void SetMaxAllocationSize(size_t limit);
++  bool Request(size_t bytes);
++  void Release(size_t bytes);
++
++ private:
++  size_t memory_limit_{limits::kVideoFrameBufferMemoryBudget};
++  size_t max_allocation_size_{limits::kVideoFrameBufferMaxAllocationSize};
++  std::atomic<size_t> allocated_{0};
++};
++
++}  // namespace media
++
++#endif
+\ No newline at end of file
+diff --git a/media/base/video_frame_memory_budget_unittest.cc b/media/base/video_frame_memory_budget_unittest.cc
+new file mode 100644
+index 0000000000000000000000000000000000000000..3fde8b02a056ef331cd5f6721a7b71e8d268823a
+--- /dev/null
++++ b/media/base/video_frame_memory_budget_unittest.cc
+@@ -0,0 +1,83 @@
++#include "media/base/video_frame_memory_budget.h"
++
++#include "base/bits.h"
++#include "media/base/video_frame.h"
++#include "testing/gtest/include/gtest/gtest.h"
++
++namespace media {
++
++class VideoFrameMemoryBudgetTest : public testing::Test {
++ public:
++  VideoFrameMemoryBudgetTest() {}
++  ~VideoFrameMemoryBudgetTest() override {}
++
++ protected:
++  void SetUp() override {
++    VideoFrameMemoryBudget::SetThreadCurrentForTesting(&test_budget_);
++  }
++
++  void TearDown() override {
++    VideoFrameMemoryBudget::SetThreadCurrentForTesting(nullptr);
++  }
++
++  size_t AllocationSizeI420(size_t width, size_t height) {
++    size_t y_stride =
++        base::bits::Align(width, VideoFrame::kFrameAddressAlignment);
++    size_t y_height =
++        base::bits::Align(height, VideoFrame::kFrameAddressAlignment);
++    size_t uv_stride =
++        base::bits::Align(width / 2, VideoFrame::kFrameAddressAlignment);
++    size_t uv_height =
++        base::bits::Align(height / 2, VideoFrame::kFrameAddressAlignment);
++
++    return y_stride * y_height + 2 * uv_stride * uv_height + uv_stride +
++           VideoFrame::kFrameSizePadding;
++  }
++
++  void SetAllocationMaxI420(size_t width, size_t height) {
++    VideoFrameMemoryBudget::Current()->SetMaxAllocationSize(
++        AllocationSizeI420(width, height));
++  }
++
++  void SetMaxFramesI420(size_t width, size_t height, size_t num) {
++    VideoFrameMemoryBudget::Current()->SetMemoryLimit(
++        AllocationSizeI420(width, height) * num);
++  }
++
++  scoped_refptr<VideoFrame> CreateFrame(size_t width, size_t height) {
++    return VideoFrame::CreateZeroInitializedFrame(
++        VideoPixelFormat::PIXEL_FORMAT_I420, gfx::Size(width, height),
++        gfx::Rect(width, height), gfx::Size(width, height), base::TimeDelta());
++  }
++
++ private:
++  VideoFrameMemoryBudget test_budget_;
++};
++
++TEST_F(VideoFrameMemoryBudgetTest, TooBigFramesDontAllocate) {
++  SetAllocationMaxI420(1280, 720);
++  EXPECT_NE(CreateFrame(1280, 720), nullptr);
++  EXPECT_EQ(CreateFrame(1282, 722), nullptr);
++}
++
++TEST_F(VideoFrameMemoryBudgetTest, TooManyBigFramesDontAllocate) {
++  const size_t kWidth = 1280;
++  const size_t kHeight = 720;
++
++  SetAllocationMaxI420(kWidth, kHeight);
++  SetMaxFramesI420(kWidth, kHeight, 4);
++
++  auto frame1 = CreateFrame(kWidth, kHeight);
++  auto frame2 = CreateFrame(kWidth, kHeight);
++  auto frame3 = CreateFrame(kWidth, kHeight);
++  auto frame4 = CreateFrame(kWidth, kHeight);
++  auto frame5 = CreateFrame(kWidth, kHeight);
++
++  EXPECT_NE(frame1, nullptr);
++  EXPECT_NE(frame2, nullptr);
++  EXPECT_NE(frame3, nullptr);
++  EXPECT_NE(frame4, nullptr);
++  EXPECT_EQ(frame5, nullptr);
++}
++
++}  // namespace media
+\ No newline at end of file
+diff --git a/media/test/run_all_unittests.cc b/media/test/run_all_unittests.cc
+index f78864381ab0fda22ce82a9ca54b5df7ab0de32b..d795f621a8092b248d019af6cc7e6f29cb4d8e94 100644
+--- a/media/test/run_all_unittests.cc
++++ b/media/test/run_all_unittests.cc
+@@ -10,6 +10,7 @@
+ #include "media/base/fake_localized_strings.h"
+ #include "media/base/media.h"
+ #include "media/base/media_switches.h"
++#include "media/base/video_frame_memory_budget.h"
+ #include "mojo/core/embedder/embedder.h"
+ 
+ #if defined(OS_ANDROID)
+@@ -46,6 +47,8 @@ void TestSuiteNoAtExit::Initialize() {
+   media::SetUpFakeLocalizedStrings();
+ 
+   base::DiscardableMemoryAllocator::SetInstance(&discardable_memory_allocator_);
++  media::VideoFrameMemoryBudget::Current()->SetMemoryLimit(SIZE_MAX);
++  media::VideoFrameMemoryBudget::Current()->SetMaxAllocationSize(SIZE_MAX);
+ }
+ 
+ int main(int argc, char** argv) {


### PR DESCRIPTION
backstory. people have been posting "gifs" (mp4s that are treated as gifv) that OOM crash the desktop client for a bit. it's all very entertaining. they contain an embedded SPS that changes the video resolution to some ridiculously high number like 12000x12000 or so. due to fun facts reasons, it's much easier to just fix the clients than filter the bad mp4s from being fetched like we were originally going to (see https://github.com/discord/lilliput/pull/90), so, ya.

chrome upstream has a "fix" https://bugs.chromium.org/p/chromium/issues/detail?id=1199230 but it's rather erroneous -- by the time it fails allocations, we are already under severe memory pressure and in my testing we just end up dying in viz anyway when submitting the frames. likewise, merely limiting the allocation size is inadequate, because multiple videos may autoplay at any time, pushing the overall pressure too high. this issue mainly affects the win32 client (its 32bitness does not help).

so this. currently it's only for the ffmpeg decode path, I will add vpx later. wanted to get your take on the fix.