### PR TITLE
Move DiscordFrame to shared header and support frame rotation

### DIFF
--- a/discord/discord_video_source.cc
+++ b/discord/discord_video_source.cc
@@ -191,7 +191,8 @@ void MediaStreamDiscordVideoSource::VideoSourceDelegate::OnFrame(
     auto* yuv = &frame.frame.yuv;
     video_frame = media::VideoFrame::WrapExternalYuvData(
         media::PIXEL_FORMAT_I420, size, gfx::Rect(size), size, yuv->y_stride,
-        yuv->u_stride, yuv->v_stride, yuv->y, yuv->u, yuv->v,
+        yuv->u_stride, yuv->v_stride, const_cast<uint8_t*>(yuv->y),
+        const_cast<uint8_t*>(yuv->u), const_cast<uint8_t*>(yuv->v),
         base::TimeDelta::FromMicroseconds(frame.timestamp_us));
 #ifdef OS_WIN
   } else if (frame.type == DISCORD_FRAME_NATIVE) {
@@ -229,6 +230,23 @@ void MediaStreamDiscordVideoSource::VideoSourceDelegate::OnFrame(
     releaseCB(userData);
     return;
   }
+  media::VideoRotation rotation;
+  switch (frame.rotation) {
+    case discord::media::electron::kRotation0:
+      rotation = media::VIDEO_ROTATION_0;
+      break;
+    case discord::media::electron::kRotation90:
+      rotation = media::VIDEO_ROTATION_90;
+      break;
+    case discord::media::electron::kRotation180:
+      rotation = media::VIDEO_ROTATION_180;
+      break;
+    case discord::media::electron::kRotation270:
+      rotation = media::VIDEO_ROTATION_270;
+      break;
+  }
+  video_frame->metadata()->SetRotation(media::VideoFrameMetadata::ROTATION,
+                                       rotation);
 
   PostCrossThreadTask(
       *io_task_runner_.get(), FROM_HERE,

--- a/discord/discord_video_source.h
+++ b/discord/discord_video_source.h
@@ -12,29 +12,8 @@
 
 namespace blink {
 
-struct DiscordYUVFrame {
-  uint8_t* y;
-  uint8_t* u;
-  uint8_t* v;
-  int32_t y_stride;
-  int32_t u_stride;
-  int32_t v_stride;
-};
-
-struct DiscordFrame {
-  int64_t timestamp_us;
-  union {
-    DiscordYUVFrame yuv;
-#if defined(OS_WIN)
-    HANDLE texture_handle;
-#endif
-    discord::media::electron::IElectronVideoFrame* electron;
-  } frame;
-  int32_t width;
-  int32_t height;
-  int32_t type;
-};
 using DiscordFrameReleaseCB = void (*)(void*);
+using discord::media::electron::DiscordFrame;
 
 class MODULES_EXPORT MediaStreamDiscordVideoSource
     : public MediaStreamVideoSource {

--- a/discord/electron_video_shared.h
+++ b/discord/electron_video_shared.h
@@ -293,6 +293,32 @@ ElectronVideoCreateObject(char const* clsid,
                           void** ppElectronObject);
 }
 
+struct DiscordYUVFrame {
+  const uint8_t* y;
+  const uint8_t* u;
+  const uint8_t* v;
+  int32_t y_stride;
+  int32_t u_stride;
+  int32_t v_stride;
+};
+
+enum Rotation : int32_t { kRotation0, kRotation90, kRotation180, kRotation270 };
+
+struct DiscordFrame {
+  int64_t timestamp_us;
+  union {
+    DiscordYUVFrame yuv;
+#if defined(_WIN32)
+    void* texture_handle;
+#endif
+    IElectronVideoFrame* electron;
+  } frame;
+  int32_t width;
+  int32_t height;
+  int32_t type;
+  Rotation rotation;
+};
+
 // This should be defined in exactly one source file to ensure the proper
 // linkage for these constants exists (similar to COM INITGUID). This can go
 // away once everybody is using C++17.


### PR DESCRIPTION
We need to pass rotation information along with video frames in direct video to avoid having to rotate frames in software. Besides being inefficient, rotating frames in software also requires readback of hardware decoded video frames which is non-trivial to support.

While I was in there I moved the definition of the DiscordFrame struct to the shared header